### PR TITLE
Register Test::Portability::Files as a develop phase prereq

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+  - Add Test::Portability::Files as a develop phase prereq on distros which
+    use this plugin. GH #5 (Dave Rolsky)
 
 2.000006  2015-01-22
   - Add the file in one shot, rather than adding then munging

--- a/lib/Dist/Zilla/Plugin/Test/Portability.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Portability.pm
@@ -9,6 +9,7 @@ use Moose;
 with qw/
     Dist::Zilla::Role::FileGatherer
     Dist::Zilla::Role::FileInjector
+    Dist::Zilla::Role::PrereqSource
     Dist::Zilla::Role::TextTemplate
 /;
 use Dist::Zilla::File::InMemory;
@@ -47,6 +48,23 @@ has options => (
   isa     => 'Str',
   default => '',
 );
+
+=for Pod::Coverage register_prereqs
+
+=cut
+
+sub register_prereqs {
+    my ($self) = @_;
+
+    $self->zilla->register_prereqs({
+            type  => 'requires',
+            phase => 'develop',
+        },
+        'Test::Portability::Files' => '0',
+    );
+
+    return;
+}
 
 =head2 munge_file
 


### PR DESCRIPTION
This causes any distro which uses this plugin to include this prereq in its META.* files. This is important for the travis-perl helpers and is just generally more correct.

Note that I tried to run the full "dzil test --release" cycle on this, but your setup requires files external to the checkout under ~/.dzil. This makes it much harder on people releasing patches. You could provide the relevant info directly from your author plugin bundle instead.